### PR TITLE
add community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 - [GitHub-maintained packages](https://github.com/orgs/codeql/packages)
 - [GitHub Security Lab community](https://github.com/GitHubSecurityLab/CodeQL-Community-Packs) - Collection of community-driven CodeQL query, library and extension [packages](https://github.com/orgs/githubsecuritylab/packages)
 - Trail of Bits - [codeql-queries](https://github.com/trailofbits/codeql-queries) - CodeQL queries and [packs](https://github.com/orgs/trailofbits/packages?ecosystem=all&q=repo%3Atrailofbits%2Fcodeql-queries) developed by Trail of Bits
-- [Microsoft solorigate queries](https://www.microsoft.com/en-us/security/blog/2021/02/25/microsoft-open-sources-codeql-queries-used-to-hunt-for-solorigate-activity/)
 - [GitHub codeql-coding-standards](https://github.com/github/codeql-coding-standards) - This repository contains CodeQL queries and libraries which support various Coding Standards. (AUTOSAR C++, CERT-C++,CERT C, MISRA C)
 
 ## CodeQL Tooling (Bundles + Packs)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 ## CodeQL [Packs](https://docs.github.com/en/code-security/codeql-cli/using-the-codeql-cli/publishing-and-using-codeql-packs)
 - [GitHub-maintained packages](https://github.com/orgs/codeql/packages)
+- [GitHub Security Lab Packages](https://github.com/orgs/githubsecuritylab/packages)
+- [TrailOfBits Packages](https://github.com/orgs/trailofbits/packages?ecosystem=all&q=repo%3Atrailofbits%2Fcodeql-queries)
 
 ## CodeQL Sharing Tooling (Bunldles + Packs)
 - [codeql-bundle-action](https://github.com/advanced-security/codeql-bundle-action) - Action to retrofit a CodeQL bundle with additional queries, libraries, and customizations
@@ -26,6 +28,8 @@
 - [Microsoft solorigate queries](https://www.microsoft.com/en-us/security/blog/2021/02/25/microsoft-open-sources-codeql-queries-used-to-hunt-for-solorigate-activity/)
 - [codeql-coding-standards](https://github.com/github/codeql-coding-standards) - This repository contains CodeQL queries and libraries which support various Coding Standards. (AUTOSAR C++, CERT-C++,CERT C, MISRA C)
 - [codeql-coding-standards-bundle-releases](https://github.com/advanced-security/codeql-coding-standards-bundle-releases) - CodeQL bundles containing the CodeQL Coding Standards queries
+- [GitHub Security Lab CodeQL-Community-Packs](https://github.com/GitHubSecurityLab/CodeQL-Community-Packs] - Collection of community-driven CodeQL query, library and extension packs
+- Trail of Bits - [codeql-queries](https://github.com/trailofbits/codeql-queries) - CodeQL queries developed by Trail of Bits
 
 ## CodeQL Query Suites
 - [Only Critical Queries sample .qls](https://github.com/zbazztian/only-critical-queries/blob/main/.github/critical-alternative.qls)


### PR DESCRIPTION
This pull request mainly includes changes to the `README.md` file. The changes are primarily updates to the links and the organization of information in the document. The most important changes include updating the GitHub Security Lab community link and adding a new link to Trail of Bits, reorganizing the CodeQL Queries/Bundles section, updating the link in the CodeQL Samples section, and removing some unnecessary blank lines.

Here are the key changes:

Updates to CodeQL Packs:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R32): The GitHub Security Lab community link was updated and a new link to Trail of Bits was added.

Reorganization of information:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R32): The CodeQL Queries/Bundles section was reorganized and updated with new links.

Updates to CodeQL Samples:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R77): The link in the CodeQL Samples section was updated.

