### PR TITLE
Add link to Chromium CodeQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Resources for extending CodeQL, creating packs, and using custom queries.
 - [trailofbits/codeql-queries](https://github.com/trailofbits/codeql-queries) - CodeQL queries and [packs](https://github.com/orgs/trailofbits/packages?ecosystem=all&q=repo%3Atrailofbits%2Fcodeql-queries) developed by Trail of Bits
 - [github/codeql-coding-standards](https://github.com/github/codeql-coding-standards) - This repository contains CodeQL queries and libraries which support various Coding Standards. (AUTOSAR C++, CERT-C++,CERT C, MISRA C)
 - [green-code-initiative/green-codeql-queries](Green-codeql-queries) - This repository contains CodeQL queries to help build sustenable code. 
+- [chromium/chromium](https://source.chromium.org/chromium/chromium/src/+/main:tools/codeql/queries/;l=1) - [Finding Bugs in Chrome with CodeQL](https://bughunters.google.com/blog/finding-bugs-in-chrome-with-codeql)
 
 ### CodeQL Tooling (Bundles + Packs)
 


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by adding a new resource link. The addition highlights how CodeQL is used for bug finding in the Chromium project.

* Added a reference to the Chromium project's CodeQL queries and a blog post about finding bugs in Chrome with CodeQL in the resources section.